### PR TITLE
MAINT: tidy up DE solver stop

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -708,6 +708,9 @@ class DifferentialEvolutionSolver(object):
         """
         Return True if the solver has converged.
         """
+        if np.any(np.isinf(self.population_energies)):
+            return False
+
         return (np.std(self.population_energies) <=
                 self.atol +
                 self.tol * np.abs(np.mean(self.population_energies)))
@@ -765,20 +768,15 @@ class DifferentialEvolutionSolver(object):
                       % (nit,
                          self.population_energies[0]))
 
-            # should the solver terminate?
-            if np.any(np.isinf(self.population_energies)):
-                intol = False
-            else:
-                intol = (np.std(self.population_energies) <=
-                         self.atol +
-                         self.tol * np.abs(np.mean(self.population_energies)))
-            if warning_flag or intol:
-                break
+            if self.callback:
+                c = self.tol / (self.convergence + _MACHEPS)
+                warning_flag = bool(self.callback(self.x, convergence=c))
+                if warning_flag:
+                    status_message = ('callback function requested stop early'
+                                      ' by returning True')
 
-            if self.callback and self.callback(self.x, convergence=self.tol / self.convergence):
-                warning_flag = True
-                status_message = ('callback function requested stop early'
-                                  ' by returning True')
+            # should the solver terminate?
+            if warning_flag or self.converged():
                 break
 
         else:


### PR DESCRIPTION
This is closer to what I was imagining. We're getting the divide by zero problem if the eventual solution is at 0.0. This is why the atol keyword was introduced. However, when that was done no additional test was done for the callback being called under that kind of situation